### PR TITLE
Update deps

### DIFF
--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import styled from 'styled-components';
 
 import Header from 'components/Header';
@@ -30,10 +30,9 @@ export function App(props) {
       <Helmet
         titleTemplate="%s - React.js Boilerplate"
         defaultTitle="React.js Boilerplate"
-        meta={[
-          { name: 'description', content: 'A React.js Boilerplate application' },
-        ]}
-      />
+      >
+        <meta name="description" content="A React.js Boilerplate application" />
+      </Helmet>
       <Header />
       {React.Children.toArray(props.children)}
       <Footer />

--- a/app/containers/FeaturePage/index.js
+++ b/app/containers/FeaturePage/index.js
@@ -4,7 +4,7 @@
  * List all the features
  */
 import React from 'react';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { FormattedMessage } from 'react-intl';
 
 import H1 from 'components/H1';
@@ -24,12 +24,10 @@ export default class FeaturePage extends React.Component { // eslint-disable-lin
   render() {
     return (
       <div>
-        <Helmet
-          title="Feature Page"
-          meta={[
-            { name: 'description', content: 'Feature page of React.js Boilerplate application' },
-          ]}
-        />
+        <Helmet>
+          <title>Feature Page</title>
+          <meta name="description" content="Feature page of React.js Boilerplate application" />
+        </Helmet>
         <H1>
           <FormattedMessage {...messages.header} />
         </H1>

--- a/app/containers/HomePage/index.js
+++ b/app/containers/HomePage/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
@@ -44,12 +44,10 @@ export class HomePage extends React.PureComponent { // eslint-disable-line react
 
     return (
       <article>
-        <Helmet
-          title="Home Page"
-          meta={[
-            { name: 'description', content: 'A React.js Boilerplate application homepage' },
-          ]}
-        />
+        <Helmet>
+          <title>Home Page</title>
+          <meta name="description" content="A React.js Boilerplate application homepage" />
+        </Helmet>
         <div>
           <CenteredSection>
             <H2>

--- a/internals/generators/container/class.js.hbs
+++ b/internals/generators/container/class.js.hbs
@@ -8,7 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 {{#if wantHeaders}}
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 {{/if}}
 {{#if wantMessages}}
 import { FormattedMessage } from 'react-intl';
@@ -29,12 +29,10 @@ export class {{ properCase name }} extends {{{ type }}} { // eslint-disable-line
     return (
       <div>
       {{#if wantHeaders}}
-        <Helmet
-          title="{{properCase name}}"
-          meta={{curly true}}[
-            {{curly true}} name: 'description', content: 'Description of {{properCase name}}' {{curly}},
-          ]{{curly}}
-        />
+        <Helmet>
+          <title>{{properCase name}}</title>
+          <meta name="description" content="Description of {{properCase name}}" />
+        </Helmet>
       {{/if}}
       {{#if wantMessages}}
         <FormattedMessage {...messages.header} />

--- a/internals/generators/container/index.js.hbs
+++ b/internals/generators/container/index.js.hbs
@@ -8,7 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 {{#if wantHeaders}}
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 {{/if}}
 {{#if wantMessages}}
 import { FormattedMessage } from 'react-intl';
@@ -26,12 +26,10 @@ export class {{ properCase name }} extends React.{{{ component }}} { // eslint-d
     return (
       <div>
       {{#if wantHeaders}}
-        <Helmet
-          title="{{properCase name}}"
-          meta={{curly true}}[
-            {{curly true}} name: 'description', content: 'Description of {{properCase name}}' {{curly}},
-          ]{{curly}}
-        />
+        <Helmet>
+          <title>{{properCase name}}</title>
+          <meta name="description" content="Description of {{properCase name}}" />
+        </Helmet>
       {{/if}}
       {{#if wantMessages}}
         <FormattedMessage {...messages.header} />

--- a/internals/generators/container/stateless.js.hbs
+++ b/internals/generators/container/stateless.js.hbs
@@ -8,7 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 {{#if wantHeaders}}
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 {{/if}}
 {{#if wantMessages}}
 import { FormattedMessage } from 'react-intl';
@@ -28,12 +28,10 @@ function {{ properCase name }}() {
   return (
     <div>
     {{#if wantHeaders}}
-      <Helmet
-        title="{{properCase name}}"
-        meta={{curly true}}[
-          {{curly true}} name: 'description', content: 'Description of {{properCase name}}' {{curly}},
-        ]{{curly}}
-      />
+      <Helmet>
+        <title>{{properCase name}}</title>
+        <meta name="description" content="Description of {{properCase name}}" />
+      </Helmet>
     {{/if}}
     {{#if wantMessages}}
       <FormattedMessage {...messages.header} />

--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -5,6 +5,12 @@
 const path = require('path');
 const webpack = require('webpack');
 
+// Remove this line once the following warning goes away (it was meant for webpack loader authors not users):
+// 'DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic,
+// see https://github.com/webpack/loader-utils/issues/56 parseQuery() will be replaced with getOptions()
+// in the next major version of loader-utils.'
+process.noDeprecation = true;
+
 module.exports = (options) => ({
   entry: options.entry,
   output: Object.assign({ // Compile into js/build.js

--- a/package.json
+++ b/package.json
@@ -191,7 +191,8 @@
       "!app/**/*.test.{js,jsx}",
       "!app/*/RbGenerated*/*.{js,jsx}",
       "!app/app.js",
-      "!app/routes.js"
+      "!app/routes.js",
+      "!app/global-styles.js"
     ],
     "coverageThreshold": {
       "global": {
@@ -289,7 +290,6 @@
     "offline-plugin": "4.8.1",
     "plop": "1.8.0",
     "pre-commit": "1.2.2",
-    "react-addons-test-utils": "15.5.1",
     "react-test-renderer": "15.5.4",
     "rimraf": "2.6.1",
     "shelljs": "0.7.7",

--- a/package.json
+++ b/package.json
@@ -191,8 +191,7 @@
       "!app/**/*.test.{js,jsx}",
       "!app/*/RbGenerated*/*.{js,jsx}",
       "!app/app.js",
-      "!app/routes.js",
-      "!app/global-styles.js"
+      "!app/routes.js"
     ],
     "coverageThreshold": {
       "global": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6349,7 +6349,7 @@ react-side-effect@^1.1.0:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
 
-react-test-renderer@^15.5.4:
+react-test-renderer@15.5.4:
   version "15.5.4"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.5.4.tgz#d4ebb23f613d685ea8f5390109c2d20fbf7c83bc"
   dependencies:


### PR DESCRIPTION
We can remove react-addons-test-utils now, it caused CI error before but with new React everything should be fine + use new react-helmet api + fixed warnings: 'DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56 parseQuery() will be replaced with getOptions() in the next major version of loader-utils.'